### PR TITLE
Enforce www and https

### DIFF
--- a/main/Dockerfile
+++ b/main/Dockerfile
@@ -11,6 +11,7 @@ COPY monitor.html /home/app/webapp/public/monitor.html
 COPY pagespeed-site.conf.template /usr/local/openresty/nginx/conf/pagespeed-site.conf.t
 COPY location.conf.template /usr/local/openresty/nginx/conf/location.conf.t
 COPY env-site.conf /usr/local/openresty/nginx/env.d/env-site.conf
+COPY nginx-httpd.conf /usr/local/openresty/nginx/conf.d/nginx-httpd.conf
 
 # Resolver IP needs to be dynamic for docker-compose tests to work.
 RUN envsubst '$RESOLVER $S3_ADDR $STORYLINES_ADDR' < /usr/local/openresty/nginx/conf/location.conf.t > /usr/local/openresty/nginx/conf/location.conf \

--- a/main/location.conf.template
+++ b/main/location.conf.template
@@ -12,9 +12,8 @@ location /s3 {
 
   proxy_pass $S3_ADDR;
   proxy_set_header X-Real-IP $remote_addr;
-  proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-  proxy_set_header        X-Forwarded-Proto $scheme;
-
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto $myscheme;
 }
 
 location /storylines {
@@ -29,17 +28,13 @@ location /storylines {
 
   proxy_pass $STORYLINES_ADDR;
   proxy_set_header X-Real-IP $remote_addr;
-  proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-  proxy_set_header        X-Forwarded-Proto $scheme;
-
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto $myscheme;
 }
 
 location / {
   rewrite_log on;
   rewrite ^/cru-nav\.js$ /cru-nav.json last;
-
-
-
   default_type 'text/plain';
 
   rewrite_by_lua_file /home/app/redirect.lua;
@@ -48,10 +43,10 @@ location / {
   access_by_lua_file /home/app/target.lua;
 
   proxy_pass $target;
-  proxy_set_header Host      $host;
+  proxy_set_header Host $host;
   proxy_set_header X-Real-IP $remote_addr;
-  proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-  proxy_set_header        X-Forwarded-Proto 'https';
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto $myscheme;
 }
 
 error_page 500 502 503 504 /500.html;

--- a/main/location.conf.template
+++ b/main/location.conf.template
@@ -18,7 +18,10 @@ location /s3 {
 }
 
 location /storylines {
-  rewrite ^/storylines([^.]*[^/])$ $1/index.html break;
+  # Add trailing slash
+  rewrite ^([^.]*[^/])$ $1/index.html;
+
+  # Rewrite to bucket root
   rewrite ^/storylines/(.*)$ /$1 break;
 
   gzip off;

--- a/main/location.conf.template
+++ b/main/location.conf.template
@@ -19,6 +19,8 @@ location /s3 {
 
 location /storylines {
   rewrite ^/storylines/(.*)$ /$1 break;
+  rewrite ^/storylines$ /index.html break;
+  gzip off;
 
   proxy_pass $STORYLINES_ADDR;
   proxy_set_header X-Real-IP $remote_addr;

--- a/main/location.conf.template
+++ b/main/location.conf.template
@@ -18,8 +18,9 @@ location /s3 {
 }
 
 location /storylines {
+  rewrite ^/storylines([^.]*[^/])$ $1/index.html break;
   rewrite ^/storylines/(.*)$ /$1 break;
-  rewrite ^/storylines$ /index.html break;
+
   gzip off;
 
   proxy_pass $STORYLINES_ADDR;

--- a/main/location.conf.template
+++ b/main/location.conf.template
@@ -19,7 +19,8 @@ location /s3 {
 
 location /storylines {
   # Add trailing slash
-  rewrite ^([^.]*[^/])$ $1/index.html;
+  rewrite ^([^.]*[^/])$ $1/;
+  rewrite ^/(.*)/$ /$1/index.html;
 
   # Rewrite to bucket root
   rewrite ^/storylines/(.*)$ /$1 break;

--- a/main/nginx-httpd.conf
+++ b/main/nginx-httpd.conf
@@ -1,0 +1,62 @@
+error_log syslog:server=unix:/var/log/nginx/error.sock;
+
+lua_shared_dict redirects 10m;
+lua_shared_dict targets 10m;
+# lua_code_cache off;
+
+#handle the X-Forwarded-Proto header
+map $http_x_forwarded_proto $myscheme {
+    default $scheme;
+    http http;
+    https https;
+}
+
+upstream puma {
+    # Path to Puma SOCK file
+    server unix:/opt/puma/sockets/puma.sock;
+    keepalive 16;
+}
+
+# Add www to non-www host and redirect to HTTPS
+server {
+    listen 80;
+    server_name cru.org;
+    access_log syslog:server=unix:/var/log/nginx/access.sock;
+    return 301 https://www.cru.org$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name cru.org;
+    ssl on;
+    ssl_certificate /usr/local/openresty/nginx/cert/cru.self.crt;
+    ssl_certificate_key /usr/local/openresty/nginx/cert/cru.self.key;
+    ssl_protocols TLSv1.1 TLSv1.2;
+    access_log syslog:server=unix:/var/log/nginx/access.sock;
+    return 301 https://www.cru.org$request_uri;
+}
+
+server {
+    listen 80 default_server;
+
+    access_log syslog:server=unix:/var/log/nginx/access.sock;
+
+    # Enforce SSL
+    if ($myscheme = "http") {
+        return 301 https://$host$request_uri;
+	}
+
+    include /usr/local/openresty/nginx/conf/location.conf;
+}
+
+server {
+    listen 443 ssl default_server;
+    ssl on;
+    ssl_certificate /usr/local/openresty/nginx/cert/cru.self.crt;
+    ssl_certificate_key /usr/local/openresty/nginx/cert/cru.self.key;
+    ssl_protocols TLSv1.1 TLSv1.2;
+
+    access_log syslog:server=unix:/var/log/nginx/access.sock;
+
+    include /usr/local/openresty/nginx/conf/location.conf;
+}

--- a/main/pagespeed-site.conf.template
+++ b/main/pagespeed-site.conf.template
@@ -1,5 +1,5 @@
 # Enable PageSpeed
-pagespeed on;
+pagespeed off;
 
 # PageSpeed will rewrite resources found from these explicitly listed domains
 pagespeed Domain $DOMAIN;

--- a/main/pagespeed-site.conf.template
+++ b/main/pagespeed-site.conf.template
@@ -1,5 +1,5 @@
 # Enable PageSpeed
-pagespeed off;
+pagespeed on;
 
 # PageSpeed will rewrite resources found from these explicitly listed domains
 pagespeed Domain $DOMAIN;


### PR DESCRIPTION
Tested locally and everything appears to work correctly.

AEM is currently stripping the https when it adds .html, so we end up with 3x 301  redirects for http://cru.org/cru17 before it resolves. This could be simplified to 2 if AEM didn't drop https.

Example:
- http://cru.org/cru17  ➡️ 301 https://www.cru.org/cru17 (cruorg_proxy)
- https://www.cru.org/cru17 ➡️ 301 http://www.cru.org/cru17.html (AEM)
- http://www.cru.org/cru17.html ➡️ 301 https://www.cru.org/cru17.html (cruorg_proxy)