### PR TITLE
Configure authentication for pagespeed_admin console

### DIFF
--- a/main/.htpasswd
+++ b/main/.htpasswd
@@ -1,0 +1,1 @@
+purge_admin:$apr1$EBEC2wZd$xdKxob7UkBnQ54aJAoMKU/

--- a/main/Dockerfile
+++ b/main/Dockerfile
@@ -13,10 +13,10 @@ COPY pagespeed-site.conf.template /usr/local/openresty/nginx/conf/pagespeed-site
 COPY location.conf.template /usr/local/openresty/nginx/conf/location.conf.t
 COPY env-site.conf /usr/local/openresty/nginx/env.d/env-site.conf
 COPY nginx-httpd.conf /usr/local/openresty/nginx/conf.d/nginx-httpd.conf
+COPY .htpasswd /usr/local/openresty/nginx/conf/.htpasswd
 
 # Resolver IP needs to be dynamic for docker-compose tests to work.
 RUN envsubst '$RESOLVER $S3_ADDR $STORYLINES_ADDR' < /usr/local/openresty/nginx/conf/location.conf.t > /usr/local/openresty/nginx/conf/location.conf \
   && rm /usr/local/openresty/nginx/conf/location.conf.t
 RUN envsubst '$DOMAIN $PROXY_ADDR $REDIS_PORT_6379_TCP_ADDR_A' < /usr/local/openresty/nginx/conf/pagespeed-site.conf.t > /usr/local/openresty/nginx/conf/pagespeed-site.conf \
   && rm /usr/local/openresty/nginx/conf/pagespeed-site.conf.t
-

--- a/main/pagespeed-site.conf.template
+++ b/main/pagespeed-site.conf.template
@@ -17,5 +17,7 @@ pagespeed MapOriginDomain $PROXY_ADDR https://cdn2-$DOMAIN $DOMAIN;
 pagespeed Disallow "*/cruicons.woff?10301097";
 
 pagespeed AdminPath /pagespeed_admin;
-location ~ ^/pagespeed_admin { allow 10.16.0.0/16; deny all; }
-
+location ~ ^/pagespeed_admin {
+                              auth_basic  "Administrator’s area";
+                              auth_basic_user_file /usr/local/openresty/nginx/conf/.htpasswd;
+                             }


### PR DESCRIPTION
*add .htpasswd with encrypted password
*update Docker file
*configured pagespeed-site.conf.template

Allows access to the pagespeed_admin console and protects it with basic authentication. 