### PR TITLE
Disallow optimization of microsite *.css files

### DIFF
--- a/main/pagespeed-site.conf.template
+++ b/main/pagespeed-site.conf.template
@@ -15,6 +15,7 @@ pagespeed MapOriginDomain $PROXY_ADDR https://cdn1-$DOMAIN $DOMAIN;
 pagespeed MapOriginDomain $PROXY_ADDR https://cdn2-$DOMAIN $DOMAIN;
 
 pagespeed Disallow "*/cruicons.woff?10301097";
+pagespeed Disallow "*/wp-content/*.css";
 
 pagespeed AdminPath /pagespeed_admin;
 location ~ ^/pagespeed_admin {


### PR DESCRIPTION
*This rule should disable PageSpeed optimization of microsite assets
under the path that matches regex "*/wp_content/*.css"
Following PageSpeed Doc:
https://www.modpagespeed.com/doc/restricting_urls


@Omicron7 
Sudarma wants me to apply this change to production because he is not able to test it on stage. Are you ok with it? 