### PR TITLE
Increase proxy buffer size.

### DIFF
--- a/main/location.conf.template
+++ b/main/location.conf.template
@@ -47,6 +47,13 @@ location / {
   access_by_lua_file /home/app/target.lua;
 
   proxy_pass $target;
+
+  # Doubles buffer size to accommodate more headers and cookies
+  # See https://www.getpagespeed.com/server-setup/nginx/tuning-proxy_buffer_size-in-nginx
+  proxy_buffer_size 16k;
+  proxy_busy_buffers_size 24k;
+  proxy_buffers 64 4k;
+
   proxy_set_header Host $proxy_host;
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/main/nginx-httpd.conf
+++ b/main/nginx-httpd.conf
@@ -49,8 +49,8 @@ server {
 
     # Enforce SSL
     if ($thescheme = "http") {
-        return 301 https://$host$request_uri;
-	  }
+      return 301 https://$host$request_uri;
+	}
 
     include /usr/local/openresty/nginx/conf/location.conf;
 }


### PR DESCRIPTION
In debugging an issue with `cruorg_proxy` producing `502` errors for specific `wp-login.php` requests with long urls/query parameters Moe found this in the DataDog logs.

> upstream sent too big header while reading response header from upstream

We discovered that the default nginx proxy buffer sizes weren't large enough to accommodate the headers/cookies sent back from WordPress. This doubles the size. It has been tested on staging any everything is functioning correctly.

See https://secure.helpscout.net/conversation/1631619866/640473?folderId=3828220