### PR TITLE
AEM Cloud Configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.env

--- a/usr/local/openresty/nginx/conf/conf.d/server.conf
+++ b/usr/local/openresty/nginx/conf/conf.d/server.conf
@@ -56,6 +56,7 @@ server {
       proxy_set_header Host $proxy_host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Host $host;
       proxy_set_header X-Forwarded-Proto $thescheme;
       proxy_set_header X-AEM-Edge-Key $env_aem_edge_key;
       proxy_ssl_server_name on;

--- a/usr/local/openresty/nginx/conf/redirect.lua
+++ b/usr/local/openresty/nginx/conf/redirect.lua
@@ -63,13 +63,13 @@ if (not target) or (target == ngx.null) then
     return
   end
 
-  arr_rewrite = red:array_to_hash(redirects)
+  local arr_rewrite = red:array_to_hash(redirects)
   -- concat scheme, host and uri to produce url
   local redirect_uri = string.lower(ngx.var.scheme .. "://" .. ngx.var.host .. ngx.var.uri)
 
   for pattern, sub in pairs(arr_rewrite) do
     -- If the uri matches this rule, redirect to the target uri
-    new_uri, index, err = ngx.re.gsub(redirect_uri, pattern, sub, "i")
+    local new_uri, index, err = ngx.re.gsub(redirect_uri, pattern, sub, "i")
     if index > 0 then
       target = new_uri
       break

--- a/usr/local/openresty/nginx/conf/target.lua
+++ b/usr/local/openresty/nginx/conf/target.lua
@@ -16,7 +16,10 @@ if not args['purge_target'] then
         if target == "DEFAULT_PROXY_TARGET" then
             -- AEM requires the Host header to be the origin domain
             -- https://experienceleague.adobe.com/docs/experience-manager-cloud-service/content/implementing/content-delivery/cdn.html?lang=en
-            ngx.var.proxy_host = resty_url.parse(os.getenv('DEFAULT_PROXY_TARGET')).host
+            local value = resty_url.parse(os.getenv('DEFAULT_PROXY_TARGET')).host
+            if value.find('adobeaemcloud.com') then
+              ngx.var.proxy_host = value
+            end
         end
         return
     end
@@ -67,5 +70,8 @@ ngx.var.target = os.getenv(target)
 if target == "DEFAULT_PROXY_TARGET" then
     -- AEM requires the Host header to be the origin domain
     -- https://experienceleague.adobe.com/docs/experience-manager-cloud-service/content/implementing/content-delivery/cdn.html?lang=en
-    ngx.var.proxy_host = resty_url.parse(os.getenv('DEFAULT_PROXY_TARGET')).host
+    local value = resty_url.parse(os.getenv('DEFAULT_PROXY_TARGET')).host
+    if value.find('adobeaemcloud.com') then
+      ngx.var.proxy_host = value
+    end
 end

--- a/usr/local/openresty/nginx/conf/target.lua
+++ b/usr/local/openresty/nginx/conf/target.lua
@@ -17,7 +17,7 @@ if not args['purge_target'] then
             -- AEM requires the Host header to be the origin domain
             -- https://experienceleague.adobe.com/docs/experience-manager-cloud-service/content/implementing/content-delivery/cdn.html?lang=en
             local value = resty_url.parse(os.getenv('DEFAULT_PROXY_TARGET')).host
-            if value.find('adobeaemcloud.com') then
+            if string.find(value, "adobeaemcloud.com") then
               ngx.var.proxy_host = value
             end
         end
@@ -71,7 +71,7 @@ if target == "DEFAULT_PROXY_TARGET" then
     -- AEM requires the Host header to be the origin domain
     -- https://experienceleague.adobe.com/docs/experience-manager-cloud-service/content/implementing/content-delivery/cdn.html?lang=en
     local value = resty_url.parse(os.getenv('DEFAULT_PROXY_TARGET')).host
-    if value.find('adobeaemcloud.com') then
+    if string.find(value, "adobeaemcloud.com") then
       ngx.var.proxy_host = value
     end
 end

--- a/usr/local/openresty/nginx/conf/target.lua
+++ b/usr/local/openresty/nginx/conf/target.lua
@@ -2,7 +2,7 @@ local resty_url = require 'resty.url'
 local ngx_targets = ngx.shared.targets
 local args = ngx.req.get_uri_args()
 -- concat scheme, host and uri to produce url
-local uri = string.lower(ngx.var.scheme .. "://" .. ngx.var.host .. ngx.var.uri)
+local uri = string.lower(ngx.var.thescheme .. "://" .. ngx.var.host .. ngx.var.uri)
 local target = nil
 local err = nil
 
@@ -34,7 +34,7 @@ if ok then
 
     local arr_upstreams, err = red:hgetall('upstreams')
     if arr_upstreams and not err then
-        upstreams = red:array_to_hash(arr_upstreams)
+        local upstreams = red:array_to_hash(arr_upstreams)
 
         for pattern, name in pairs(upstreams) do
             -- If the uri matches this pattern, set the the named target
@@ -59,7 +59,7 @@ if (not target) or (target == ngx.null) then
 end
 
 -- Store target for 1 hour
-success, err, forcible = ngx_targets:set(uri, target, 3600)
+local success, err, forcible = ngx_targets:set(uri, target, 3600)
 
 ngx.var.target = os.getenv(target)
 

--- a/usr/local/openresty/nginx/conf/target.lua
+++ b/usr/local/openresty/nginx/conf/target.lua
@@ -12,6 +12,12 @@ if not args['purge_target'] then
     target, err = ngx_targets:get(uri)
     if target then
         ngx.var.target = os.getenv(target)
+        -- specific upstreams require a different Host header
+        if target == "DEFAULT_PROXY_TARGET" then
+            -- AEM requires the Host header to be the origin domain
+            -- https://experienceleague.adobe.com/docs/experience-manager-cloud-service/content/implementing/content-delivery/cdn.html?lang=en
+            ngx.var.proxy_host = resty_url.parse(os.getenv('DEFAULT_PROXY_TARGET')).host
+        end
         return
     end
 end
@@ -56,3 +62,10 @@ end
 success, err, forcible = ngx_targets:set(uri, target, 3600)
 
 ngx.var.target = os.getenv(target)
+
+-- specific upstreams require a different Host header
+if target == "DEFAULT_PROXY_TARGET" then
+    -- AEM requires the Host header to be the origin domain
+    -- https://experienceleague.adobe.com/docs/experience-manager-cloud-service/content/implementing/content-delivery/cdn.html?lang=en
+    ngx.var.proxy_host = resty_url.parse(os.getenv('DEFAULT_PROXY_TARGET')).host
+end


### PR DESCRIPTION
This PR provides changes in support of proxying requests to the AEM Cloud CDN.

The proxy server effectively acts as "CDN" for www.cru.org.  See CloudFront CDN configuration 'companion' PR https://github.com/CruGlobal/cru-terraform/pull/2473 for non www.cru.org site(s).

These changes are (in theory) backwards compatible with AEM on premise solution.

Target **staging** delivery date 8/1.
Target prod-cloud.cru.org **production** delivery date 1/10/23.
Target cru.org **production** delivery date 3/31/23.

Note that the proxy server now also needs to be able to handle proxying SSL requests to the AEM Adobe Cloud CDN (i.e. `DEFAULT_PROXY_TARGET` https protocol). (not sure if it currently can do so).

[CDN in AEM as a Cloud Service](https://experienceleague.adobe.com/docs/experience-manager-cloud-service/content/implementing/content-delivery/cdn.html):

Note that this PR does not set `Host` header as per instructions below (nor does the companion PR referenced above as CloudFront prohibits setting the header).  However, it may very well be that it need not be set as per instructions below (and in fact possibly should not as Adobe documentation has before been found to be incorrect). We'll verify during testing in staging.

> **Configuration instructions:**
> 
> Point your CDN to the Adobe CDN’s ingress as its origin domain. For example, publish-p<PROGRAM_ID>-e<ENV-ID>.adobeaemcloud.com.
> 
> SNI must also be set to the Adobe CDN’s ingress.
> 
> Set the Host header to the origin domain. For example: Host:publish-p<PROGRAM_ID>-e<ENV-ID>.adobeaemcloud.com.
> 
> Set the X-Forwarded-Host header with the domain name so AEM can determine the host header. For example: X-Forwarded-Host:example.com.
> 
> Set X-AEM-Edge-Key. The value should come from Adobe.