### PR TITLE
Proxy_pass geo headers

### DIFF
--- a/usr/local/openresty/nginx/conf/conf.d/server.conf
+++ b/usr/local/openresty/nginx/conf/conf.d/server.conf
@@ -34,6 +34,7 @@ server {
       rewrite ^/cru-nav\.js$ /cru-nav.json last;
       default_type 'text/plain';
       add_header cloudfront-viewer-country $http_cloudfront_viewer_country;
+      add_header accept-language $http_accept_language;
 
       rewrite_by_lua_file /usr/local/openresty/nginx/conf/redirect.lua;
 

--- a/usr/local/openresty/nginx/conf/conf.d/server.conf
+++ b/usr/local/openresty/nginx/conf/conf.d/server.conf
@@ -57,6 +57,8 @@ server {
       proxy_set_header X-Forwarded-Host $host;
       proxy_set_header X-Forwarded-Proto $thescheme;
       proxy_set_header X-AEM-Edge-Key $env_aem_edge_key;
+      proxy_set_header Accept-Language $http_accept_language;
+      proxy_set_header CloudFront-Viewer-Country $http_cloudfront_viewer_country;
       proxy_ssl_server_name on;
       proxy_ssl_protocols TLSv1.1 TLSv1.2;
     }


### PR DESCRIPTION
Add geolocation header to the proxy upstream request. 
- Accept-Language
- CloudFront-Viewer-Country

Reference: 
https://www.digitalocean.com/community/tutorials/understanding-nginx-http-proxying-load-balancing-buffering-and-caching
http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass_header
https://stackoverflow.com/questions/19751313/forward-request-headers-from-nginx-proxy-server
https://serverfault.com/questions/586970/nginx-is-not-forwarding-a-header-value-when-using-proxy-pass
https://stackoverflow.com/questions/40933057/nginx-set-proxy-set-header-if-header-is-present
https://serversforhackers.com/c/nginx-mapping-headers