### PR TITLE
Use the VPC default DNS resolver.

### DIFF
--- a/usr/local/openresty/nginx/conf/nginx.conf
+++ b/usr/local/openresty/nginx/conf/nginx.conf
@@ -25,9 +25,9 @@ http {
     include       mime.types;
     default_type  application/octet-stream;
 
-    # Without explicitly setting our own DNS server as the resolver, nginx can't resolve internal dns
-    # entries on AWS.
-    resolver 10.16.2.22 10.16.3.22 ipv6=off;
+    # Nginx/openresty can't resolve any domain names without a resolver.
+    # We use the VPC default resolver.
+    resolver 10.16.0.2 ipv6=off;
 
     # Set real ip if request forwarded from VPC (vpc-dc2d9fb9) CIDR
     set_real_ip_from 10.16.0.0/16;


### PR DESCRIPTION
The BIND servers are acting up. One of them isn't resolving private zone records anymore. We've determined we don't need these server anymore and we can use the VPC default resolver instead. 